### PR TITLE
POPS-37 - Add mongodb task_definition

### DIFF
--- a/project-apps-dev/ProgrammersOnly/mongodb_service.tf
+++ b/project-apps-dev/ProgrammersOnly/mongodb_service.tf
@@ -1,0 +1,58 @@
+data "template_file" "mongodb" {
+  template = "${file("ProgrammersOnly/task_definitions/mongodb_task_definition.json")}"
+}
+
+resource "aws_ecs_task_definition" "mongodb" {
+  family                = "mongodb"
+  container_definitions = file("ProgrammersOnly/task_definitions/mongodb_task_definition.json")
+}
+
+data "aws_ecs_task_definition" "mongodb" {
+  task_definition = aws_ecs_task_definition.mongodb.family
+  depends_on      = [aws_ecs_task_definition.mongodb]
+}
+
+resource "aws_ecr_repository" "mongodb" {
+  name = "mongodb"
+}
+
+resource "aws_ecr_repository_policy" "mongodb" {
+  repository = aws_ecr_repository.mongodb.name
+
+  policy = <<EOF
+{
+    "Version": "2008-10-17",
+    "Statement": [
+        {
+            "Sid": "MONGODB_ECR",
+            "Effect": "Allow",
+            "Principal": "*",
+            "Action": [
+                "ecr:GetDownloadUrlForLayer",
+                "ecr:BatchGetImage",
+                "ecr:BatchCheckLayerAvailability",
+                "ecr:PutImage",
+                "ecr:InitiateLayerUpload",
+                "ecr:UploadLayerPart",
+                "ecr:CompleteLayerUpload",
+                "ecr:DescribeRepositories",
+                "ecr:GetRepositoryPolicy",
+                "ecr:ListImages",
+                "ecr:DeleteRepository",
+                "ecr:BatchDeleteImage",
+                "ecr:SetRepositoryPolicy",
+                "ecr:DeleteRepositoryPolicy"
+            ]
+        }
+    ]
+}
+EOF
+}
+
+resource "aws_ecs_service" "mongodb" {
+  name                               = "mongodb"
+  cluster                            = aws_ecs_cluster.programmers_only.id
+  task_definition                    = "mongodb:${data.aws_ecs_task_definition.mongodb.revision}"
+  desired_count                      = 1
+  deployment_minimum_healthy_percent = 0
+}

--- a/project-apps-dev/ProgrammersOnly/task_definitions/mongodb_task_definition.json
+++ b/project-apps-dev/ProgrammersOnly/task_definitions/mongodb_task_definition.json
@@ -1,0 +1,26 @@
+[
+    {
+        "name": "mongo",
+        "image": "mongo:latest",
+        "cpu": 10,
+        "memory": 1024,
+        "portMappings": [
+            {
+                "containerPort": 27017,
+                "hostPort": 27017,
+                "protocol": "tcp"
+            }
+        ],
+        "command": ["mongod", "--auth"],
+        "environment": [
+            {
+                "name": "MONGO_INITDB_ROOT_USERNAME",
+                "value": "root"
+            },
+            {
+                "name": "MONGO_INITDB_ROOT_PASSWORD",
+                "value": "root"
+            }
+        ]
+    }
+]


### PR DESCRIPTION
Security concern: root user/password hardcoded.
Maybe `.env` file stored in the S3 bucket?

AWS documentation:

```
"environmentFiles": [
    {
        "value": "arn:aws:s3:::s3_bucket_name/envfile_object_name.env",
        "type": "s3"
    }
],
```